### PR TITLE
Port to setuptools, PEP517

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,15 @@
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "elogv"
+version = "0.8.0"
+authors = [
+    {name = "Luca Marturana", email = "lucamarturana@gmail.com"},
+]
+license = {text = "GPL-2"}
+description = "Curses based utility to view elogs created by Portage"
+
+[project.urls]
+homepage = "https://gitweb.gentoo.org/proj/elogv.git/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ authors = [
 ]
 license = {text = "GPL-2"}
 description = "Curses based utility to view elogs created by Portage"
+dependencies = ["portage"]
 
 [project.urls]
 homepage = "https://gitweb.gentoo.org/proj/elogv.git/"
+
+[project.optional-dependencies]
+lzma = [ "pyliblzma" ]

--- a/setup.py
+++ b/setup.py
@@ -204,14 +204,7 @@ class install_manpages(Command):
 
 man_pages = glob("man/*")
 
-setup(name="elogv",
-      version="0.8.0",
-      author="Luca Marturana",
-      author_email="lucamarturana@gmail.com",
-      license="GPL-2",
-      description="Curses based utility to view elogs created by Portage",
-      url="https://gitweb.gentoo.org/proj/elogv.git/",
-      packages=[],
+setup(packages=[],
       scripts=['elogv'],
       cmdclass={
           'extract_messages': messages,

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 from distutils.core import setup
-from distutils import log
 from distutils.cmd import Command
 from distutils.file_util import copy_file
 from distutils.dir_util import remove_tree
 from distutils.command.build import build as _build
 from distutils.command.install import install as _install
 from distutils.command.clean import clean as _clean
+
+import logging
 
 import os
 from glob import glob
@@ -33,7 +34,7 @@ class messages(Command):
     def run(self):
         wd = os.getcwd()
         name = self.distribution.get_name()
-        log.info('Extracting messages from %s' % name)
+        logging.info('Extracting messages from %s' % name)
         os.chdir('po')
         os.system('pygettext -k i18n -o %s.pot ../%s' % (name, name))
         os.chdir(wd)
@@ -60,7 +61,7 @@ class merge(Command):
             if os.path.exists(filename):
                 self.merge(filename)
             else:
-                log.error('No catalog found for language %s' % self.lang)
+                logging.error('No catalog found for language %s' % self.lang)
         else:
             files = glob('*.po')
             for f in files:
@@ -69,7 +70,7 @@ class merge(Command):
 
     def merge(self, f):
         name = self.distribution.get_name()
-        log.info('Merging catalog %s' % f)
+        logging.info('Merging catalog %s' % f)
         os.system('msgmerge %s %s.pot -o %s' % (f, name, f))
 
 
@@ -93,7 +94,7 @@ class build_messages(Command):
             base = os.path.basename(f)
             base = os.path.splitext(base)[0]
             out_file = os.path.join(self.build_dir, '%s.gmo' % base)
-            log.info('Building catalog %s > %s' % (f, out_file))
+            logging.info('Building catalog %s > %s' % (f, out_file))
             cmd = 'msgfmt -o "%s" %s' % (out_file, f)
             os.system(cmd)
 
@@ -181,7 +182,7 @@ class clean(_clean):
         if os.path.exists(self.build_temp):
             remove_tree(self.build_temp, dry_run=self.dry_run)
         else:
-            log.debug("'%s' does not exist -- can't clean it", self.build_temp)
+            logging.debug("'%s' does not exist -- can't clean it", self.build_temp)
 
         if self.all:
             # remove build directories
@@ -190,7 +191,7 @@ class clean(_clean):
                 if os.path.exists(directory):
                     remove_tree(directory, dry_run=self.dry_run)
                 else:
-                    log.warn("'%s' does not exist -- can't clean it",
+                    logging.warn("'%s' does not exist -- can't clean it",
                              directory)
 
         # just for the heck of it, try to remove the base build directory:
@@ -198,7 +199,7 @@ class clean(_clean):
         if not self.dry_run:
             try:
                 os.rmdir(self.build_base)
-                log.info("removing '%s'", self.build_base)
+                logging.info("removing '%s'", self.build_base)
             except OSError:
                 pass
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from distutils.file_util import copy_file
-
 from setuptools import setup
 from setuptools import Command
 from setuptools.command.build import build as _build
@@ -155,7 +153,7 @@ class install_messages(Command):
             self.mkpath(out_dir)
             out_file = os.path.join(out_dir,
                                     '%s.mo' % self.distribution.get_name())
-            copy_file(c, out_file)
+            self.copy_file(c, out_file)
 
 
 ## Class modified to add manpages command

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
-from distutils.core import setup
-from distutils.cmd import Command
 from distutils.file_util import copy_file
-from distutils.dir_util import remove_tree
-from distutils.command.build import build as _build
-from distutils.command.install import install as _install
-from distutils.command.clean import clean as _clean
+
+from setuptools import setup
+from setuptools import Command
+from setuptools.command.build import build as _build
+from setuptools.command.install import install as _install
 
 import logging
 
@@ -159,51 +158,6 @@ class install_messages(Command):
             copy_file(c, out_file)
 
 
-class clean(_clean):
-    _clean.user_options.append(
-        ('build-messages=', None,
-         "build directory for messages (default: 'build.build-messages')"))
-
-    def initialize_options(self):
-        _clean.initialize_options(self)
-        self.build_messages = None
-
-    def finalize_options(self):
-        self.set_undefined_options('build', ('build_base', 'build_base'),
-                                   ('build_lib', 'build_lib'),
-                                   ('build_scripts', 'build_scripts'),
-                                   ('build_temp', 'build_temp'),
-                                   ('build_messages', 'build_messages'))
-        self.set_undefined_options('bdist', ('bdist_base', 'bdist_base'))
-
-    def run(self):
-        # remove the build/temp.<plat> directory (unless it's already
-        # gone)
-        if os.path.exists(self.build_temp):
-            remove_tree(self.build_temp, dry_run=self.dry_run)
-        else:
-            logging.debug("'%s' does not exist -- can't clean it", self.build_temp)
-
-        if self.all:
-            # remove build directories
-            for directory in (self.build_lib, self.bdist_base,
-                              self.build_scripts, self.build_messages):
-                if os.path.exists(directory):
-                    remove_tree(directory, dry_run=self.dry_run)
-                else:
-                    logging.warn("'%s' does not exist -- can't clean it",
-                             directory)
-
-        # just for the heck of it, try to remove the base build directory:
-        # we might have emptied it right now, but if not we don't care
-        if not self.dry_run:
-            try:
-                os.rmdir(self.build_base)
-                logging.info("removing '%s'", self.build_base)
-            except OSError:
-                pass
-
-
 ## Class modified to add manpages command
 class install(_install):
     def has_messages(self):
@@ -269,5 +223,4 @@ setup(name="elogv",
           'install_messages': install_messages,
           'install_manpages': install_manpages,
           'install': install,
-          'clean': clean
       })


### PR DESCRIPTION
Would address this https://bugs.gentoo.org/841134. 

And allows using python3.12 now that it has a release and has completely removed distutils.

Decided to not touch modify setup.py further as options for building and installing gettext hasn't improved much. Looked at https://github.com/breezy-team/setuptools-gettext, but it didn't install them correctly (and I wasn't keen on troubleshooting it further).

Pyliblzma could be removed or ported away from as that had its last release in 2010. https://docs.python.org/3/library/lzma.html?

And adding a maintainer to the package metadata could be an idea.

Before:
```
Archive:  old_dist/elogv-0.8.0-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
     3910  10-05-2023 04:47   elogv-0.8.0.data/data/share/locale/de/LC_MESSAGES/elogv.mo
     4148  10-05-2023 04:47   elogv-0.8.0.data/data/share/locale/es/LC_MESSAGES/elogv.mo
     4022  10-05-2023 04:47   elogv-0.8.0.data/data/share/locale/it/LC_MESSAGES/elogv.mo
     3943  10-05-2023 04:47   elogv-0.8.0.data/data/share/locale/pl/LC_MESSAGES/elogv.mo
     2025  10-05-2023 04:02   elogv-0.8.0.data/data/share/man/de/man1/elogv.1.de
     2355  10-05-2023 04:02   elogv-0.8.0.data/data/share/man/es/man1/elogv.1.es
     2225  10-05-2023 04:02   elogv-0.8.0.data/data/share/man/it/man1/elogv.1.it
     1886  10-04-2023 18:21   elogv-0.8.0.data/data/share/man/man1/elogv.1
     2109  10-05-2023 04:02   elogv-0.8.0.data/data/share/man/pl/man1/elogv.1.pl
    24684  10-05-2023 04:47   elogv-0.8.0.data/scripts/elogv
      242  10-05-2023 04:47   elogv-0.8.0.dist-info/METADATA
       92  10-05-2023 04:47   elogv-0.8.0.dist-info/WHEEL
        1  10-05-2023 04:47   elogv-0.8.0.dist-info/top_level.txt
     1365  10-05-2023 04:47   elogv-0.8.0.dist-info/RECORD
---------                     -------
    53007                     14 files
```

After:
```
Archive:  dist/elogv-0.8.0-py3-none-any.whl
  Length      Date    Time    Name
---------  ---------- -----   ----
     3910  10-05-2023 04:47   elogv-0.8.0.data/data/share/locale/de/LC_MESSAGES/elogv.mo
     4148  10-05-2023 04:47   elogv-0.8.0.data/data/share/locale/es/LC_MESSAGES/elogv.mo
     4022  10-05-2023 04:47   elogv-0.8.0.data/data/share/locale/it/LC_MESSAGES/elogv.mo
     3943  10-05-2023 04:47   elogv-0.8.0.data/data/share/locale/pl/LC_MESSAGES/elogv.mo
     2025  10-05-2023 04:02   elogv-0.8.0.data/data/share/man/de/man1/elogv.1.de
     2355  10-05-2023 04:02   elogv-0.8.0.data/data/share/man/es/man1/elogv.1.es
     2225  10-05-2023 04:02   elogv-0.8.0.data/data/share/man/it/man1/elogv.1.it
     1886  10-04-2023 18:21   elogv-0.8.0.data/data/share/man/man1/elogv.1
     2109  10-05-2023 04:02   elogv-0.8.0.data/data/share/man/pl/man1/elogv.1.pl
    24684  10-05-2023 04:47   elogv-0.8.0.data/scripts/elogv
      270  10-05-2023 04:47   elogv-0.8.0.dist-info/METADATA
       92  10-05-2023 04:47   elogv-0.8.0.dist-info/WHEEL
        1  10-05-2023 04:47   elogv-0.8.0.dist-info/top_level.txt
     1365  10-05-2023 04:47   elogv-0.8.0.dist-info/RECORD
---------                     -------
    53035                     14 files
```